### PR TITLE
Buffer type fix for YUV to RGB conversion

### DIFF
--- a/yuv.ts
+++ b/yuv.ts
@@ -11,7 +11,7 @@ export function YUV2RBG(yuv: Uint8Array, width: number, height: number) {
   const uStart = width * height;
   const halfWidth = (width >>> 1);
   const vStart = uStart + (uStart >>> 2);
-  const rgb = new Uint8Array(uStart * 3);
+  const rgb = new Uint8ClampedArray(uStart * 3);
 
   let i = 0;
   for (let y = 0; y < height; y++) {


### PR DESCRIPTION
Since RGB24 can only contain values from 0 to 255 in each color channel it has to be limited with Uint8ClampedArray.

I used FFMPEG with this library and had strange color artifacts on some pixels.

Setting the strict type fixed it for me.